### PR TITLE
Fix conflicting rsqrt definition on GNU/Linux

### DIFF
--- a/src/dos/main.c
+++ b/src/dos/main.c
@@ -163,7 +163,7 @@ static int handle_sball_event(sball_event *ev)
 			float ry = (float)RY(ev);
 			float rz = (float)RZ(ev);
 
-			float s = (float)rsqrt(rx * rx + ry * ry + rz * rz);
+			float s = (float)fast_rsqrt(rx * rx + ry * ry + rz * rz);
 			cgm_qrotate(&sball_rot, 0.001 / s, -rx * s, -ry * s, - rz * s);
 		}
 

--- a/src/glut/main.c
+++ b/src/glut/main.c
@@ -561,7 +561,7 @@ static void sball_rotate(int rx, int ry, int rz)
 	cgm_vcons(&sb_rmot, -rx, -ry, rz);
 #else
 	if(rx | ry | rz) {
-		float s = (float)rsqrt(rx * rx + ry * ry + rz * rz);
+		float s = (float)fast_rsqrt(rx * rx + ry * ry + rz * rz);
 		cgm_qrotate(&sball_rot, -0.001f / s, rx * s, ry * s, -rz * s);
 	}
 #endif

--- a/src/glut/miniglut.c
+++ b/src/glut/miniglut.c
@@ -2359,7 +2359,7 @@ static void bezier_patch(float *res, float *cp, float u, float v)
 	}
 }
 
-static float rsqrt(float x)
+static float fast_rsqrt(float x)
 {
 	float xhalf = x * 0.5f;
 	int i = *(int*)&x;
@@ -2379,7 +2379,7 @@ static float rsqrt(float x)
 
 #define NORMALIZE(v) \
 	do { \
-		float s = rsqrt((v)[0] * (v)[0] + (v)[1] * (v)[1] + (v)[2] * (v)[2]); \
+		float s = fast_rsqrt((v)[0] * (v)[0] + (v)[1] * (v)[1] + (v)[2] * (v)[2]); \
 		(v)[0] *= s; \
 		(v)[1] *= s; \
 		(v)[2] *= s; \

--- a/src/sdl/main.c
+++ b/src/sdl/main.c
@@ -449,7 +449,7 @@ static int handle_sball_event(sball_event *ev)
 			float ry = (float)RY(ev);
 			float rz = (float)RZ(ev);
 
-			float s = (float)rsqrt(rx * rx + ry * ry + rz * rz);
+			float s = (float)fast_rsqrt(rx * rx + ry * ry + rz * rz);
 			cgm_qrotate(&sball_rot, 0.001 / s, -rx * s, -ry * s, - rz * s);
 		}
 

--- a/src/util.h
+++ b/src/util.h
@@ -82,7 +82,7 @@ static INLINE void read_unaligned32(void *dest, void *src)
 }
 #endif
 
-static INLINE float rsqrt(float x)
+static INLINE float fast_rsqrt(float x)
 {
 	float xhalf = x * 0.5f;
 	int32_t i = *(int32_t*)&x;
@@ -95,7 +95,7 @@ static INLINE float rsqrt(float x)
 #define fast_vnormalize(vptr)	fast_normalize((float*)(vptr))
 static INLINE void fast_normalize(float *v)
 {
-	float s = rsqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+	float s = fast_rsqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
 	v[0] *= s;
 	v[1] *= s;
 	v[2] *= s;


### PR DESCRIPTION
Hi. When building on Arch Linux (`Linux 6.16.1`, `glibc 2.42+r17+gd7274d718e6f`, `gcc 15.2.1+r22+gc4e96a094636`), I encountered the following compiler error:
```
cc -m32 -pedantic -Wall -Wno-unused-variable -Wno-unused-function -Wno-address -MMD -O3 -ffast-math -DMINIGLUT_USE_LIBC -DMIKMOD_STATIC -DNDEBUG -fno-pie -fno-strict-aliasing  -Isrc -Isrc/3dgfx -Isrc/rt -Isrc/scr -Isrc/utils -Isrc/glut -Ilibs -Ilibs/imago/src -Ilibs/anim/src -Ilibs/mikmod/include -Ilibs/goat3d/include -I/usr/local/include   -c -o src/bsptree.o src/bsptree.c
In file included from src/vmath.h:5,
                 from src/bsptree.h:5,
                 from src/bsptree.c:6:
src/util.h:85:21: error: conflicting types for ‘rsqrt’; have ‘float(float)’
   85 | static INLINE float rsqrt(float x)
      |                     ^~~~~
In file included from /usr/include/features.h:524,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from src/bsptree.c:1:
/usr/include/bits/mathcalls.h:206:1: note: previous declaration of ‘rsqrt’ with type ‘double(double)’
  206 | __MATHCALL (rsqrt,, (_Mdouble_ __x));
      | ^~~~~~~~~~
make: *** [<builtin>: src/bsptree.o] Error 1
```

I decided to fix this by renaming the fast rsqrt implementation `rsqrt0` (suffix as in the project's name).